### PR TITLE
Fix: force order of initialization for constants

### DIFF
--- a/QuadrupleLib/Modules/Constants.cs
+++ b/QuadrupleLib/Modules/Constants.cs
@@ -20,6 +20,15 @@ namespace QuadrupleLib;
 
 public partial struct Float128
 {
+    #region Private API (constants)
+
+    private static readonly UInt128 SIGNIFICAND_MASK = UInt128.MaxValue >> 16;
+    private static readonly UInt128 EXPONENT_MASK = ~SIGNIFICAND_MASK ^ SIGNBIT_MASK;
+    private static readonly UInt128 SIGNBIT_MASK = (UInt128.MaxValue >> 1) + 1;
+    private static readonly ushort EXPONENT_BIAS = short.MaxValue >> 1;
+
+    #endregion
+
     #region Public API (constants)
 
     private static readonly Float128 _qNaN = new Float128(UInt128.One, short.MaxValue, false);

--- a/QuadrupleLib/Modules/StorageOperations.cs
+++ b/QuadrupleLib/Modules/StorageOperations.cs
@@ -20,15 +20,6 @@ namespace QuadrupleLib;
 
 public partial struct Float128
 {
-    #region Useful constants
-
-    private static readonly UInt128 SIGNIFICAND_MASK = UInt128.MaxValue >> 16;
-    private static readonly UInt128 EXPONENT_MASK = ~SIGNIFICAND_MASK ^ SIGNBIT_MASK;
-    private static readonly UInt128 SIGNBIT_MASK = ~(UInt128.MaxValue >> 1);
-    private static readonly ushort EXPONENT_BIAS = short.MaxValue >> 1;
-
-    #endregion
-
     #region Raw storage properties
 
     private UInt128 _rawBits;


### PR DESCRIPTION
This PR fixes a critical issue where the bit-twiddling constants would initialize after API constants, causing them to initialize incorrectly. 