### PR TITLE
Fix: `AtanPi` shouldn't divide after final FMA

### DIFF
--- a/QuadrupleLib/Modules/MathOperations.cs
+++ b/QuadrupleLib/Modules/MathOperations.cs
@@ -212,7 +212,7 @@ public partial struct Float128
         for (int n = 0; n < 25; n++)
         {
             (Float128 sin, Float128 cos) = SinCosPi(y_n);
-            y_n = FusedMultiplyAdd(FusedMultiplyAdd(x, cos, -sin), cos, y_n) / Pi;
+            y_n = FusedMultiplyAdd(FusedMultiplyAdd(x, cos, -sin), cos / Pi, y_n);
         }
         return y_n;
     }


### PR DESCRIPTION
This PR addresses an error introduced in  #26 where the division by `Pi` happens after adding to the current `y_n`, rather than before. Now, the division occurs during the final multiplication, which is the correct behavior. 