### PR TITLE
Fix: upgrade library to .NET 10

### DIFF
--- a/QuadrupleLib/QuadrupleLib.csproj
+++ b/QuadrupleLib/QuadrupleLib.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 	<OutputType>Library</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This PR upgrades QuadrupleLib to build with and depend on the .NET 10 Runtime. This is to ensure that the library uses the latest LTS release of .NET and continues to be supported years into the future. 