### PR TITLE
Fix: use more informative exception for `CompareTo`

### DIFF
--- a/QuadrupleLib/Modules/ComparisonOperations.cs
+++ b/QuadrupleLib/Modules/ComparisonOperations.cs
@@ -35,7 +35,7 @@ public partial struct Float128<TAccelerator>
         }
         else
         {
-            throw new InvalidOperationException();
+            throw new ArgumentException($"Provided value must be of type {nameof(Float128<TAccelerator>)}.", nameof(obj));
         }
     }
 


### PR DESCRIPTION
This PR throws a more detailed exception in cases when an invalid object is passed to the `IComparable.CompareTo` implementation in `Float128`.