### PR TITLE
Fix: guard `GetGenericTypeDefinition` with `IsGenericType`

### DIFF
--- a/QuadrupleLib/Modules/ConversionOperations.cs
+++ b/QuadrupleLib/Modules/ConversionOperations.cs
@@ -27,7 +27,7 @@ public partial struct Float128<TAccelerator>
 
     static bool INumberBase<Float128<TAccelerator>>.TryConvertFromChecked<TOther>(TOther value, out Float128<TAccelerator> result)
     {
-        if (typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
+        if (typeof(TOther).IsGenericType && typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
         {
             result = Unsafe.BitCast<TOther, Float128<TAccelerator>>(value);
             return true;
@@ -95,7 +95,7 @@ public partial struct Float128<TAccelerator>
 
     static bool INumberBase<Float128<TAccelerator>>.TryConvertFromSaturating<TOther>(TOther value, out Float128<TAccelerator> result)
     {
-        if (typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
+        if (typeof(TOther).IsGenericType && typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
         {
             result = Unsafe.BitCast<TOther, Float128<TAccelerator>>(value);
             return true;
@@ -163,7 +163,7 @@ public partial struct Float128<TAccelerator>
 
     static bool INumberBase<Float128<TAccelerator>>.TryConvertFromTruncating<TOther>(TOther value, out Float128<TAccelerator> result)
     {
-        if (typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
+        if (typeof(TOther).IsGenericType && typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
         {
             result = Unsafe.BitCast<TOther, Float128<TAccelerator>>(value);
             return true;
@@ -231,7 +231,7 @@ public partial struct Float128<TAccelerator>
 
     static bool INumberBase<Float128<TAccelerator>>.TryConvertToChecked<TOther>(Float128<TAccelerator> value, out TOther result)
     {
-        if (typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
+        if (typeof(TOther).IsGenericType && typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
         {
             result = Unsafe.BitCast<Float128<TAccelerator>, TOther>(value);
             return true;
@@ -267,7 +267,7 @@ public partial struct Float128<TAccelerator>
 
     static bool INumberBase<Float128<TAccelerator>>.TryConvertToSaturating<TOther>(Float128<TAccelerator> value, out TOther result)
     {
-        if (typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
+        if (typeof(TOther).IsGenericType && typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
         {
             result = Unsafe.BitCast<Float128<TAccelerator>, TOther>(value);
             return true;
@@ -303,7 +303,7 @@ public partial struct Float128<TAccelerator>
 
     static bool INumberBase<Float128<TAccelerator>>.TryConvertToTruncating<TOther>(Float128<TAccelerator> value, out TOther result)
     {
-        if (typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
+        if (typeof(TOther).IsGenericType && typeof(TOther).GetGenericTypeDefinition() == typeof(Float128<>))
         {
             result = Unsafe.BitCast<Float128<TAccelerator>, TOther>(value);
             return true;


### PR DESCRIPTION
This PR fixes an oversight where QuadrupleLib always calls `GetGenericTypeDefinition` at the beginning of conversion methods. Sometimes, this call is not valid because the provided type is not generically defined, in which case we shouldn't call it and instead fallback to the rest of the method's logic. 