### PR TITLE
CI: allow duplicate packages on NuGet publish

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -27,9 +27,10 @@ jobs:
         run: dotnet build QuadrupleLib --no-restore --configuration Release
       - name: Create NuGet packages
         run: dotnet pack --no-build --output build/
-      - name: Publish to NuGet
-        run: dotnet nuget push --api-key ${{ secrets.API_KEY }} --source nuget.org build/**/*.nupkg
       - name: Create new release
         uses: ncipollo/release-action@v1
         with:
+          artifacts: build/**/*.nupkg
           generateReleaseNotes: true
+      - name: Publish to NuGet
+        run: dotnet nuget push --api-key ${{ secrets.API_KEY }} --source nuget.org build/**/*.nupkg --skip-duplicate


### PR DESCRIPTION
This PR fixes the NuGet CI workflow such that:
1. A GitHub release is generated _before_ `dotnet nuget push` 
2. `dotnet nuget push` uses the `--skip-duplicate` flag to avoid failures when rerunning CI

The workflow additionally now includes the `.nupkg` output files as artifacts in the GitHub release it creates. 