### PR TITLE
CI: use trusted publishing for NuGet publish

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -10,7 +10,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Setup .NET
@@ -27,10 +29,15 @@ jobs:
         run: dotnet build QuadrupleLib --no-restore --configuration Release
       - name: Create NuGet packages
         run: dotnet pack --no-build --output build/
+      - name: NuGet login (OIDC → temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USERNAME }}
+      - name: Publish to NuGet
+        run: dotnet nuget push --api-key ${{ steps.login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json build/**/*.nupkg --skip-duplicate
       - name: Create new release
         uses: ncipollo/release-action@v1
         with:
           artifacts: build/**/*.nupkg
           generateReleaseNotes: true
-      - name: Publish to NuGet
-        run: dotnet nuget push --api-key ${{ secrets.API_KEY }} --source nuget.org build/**/*.nupkg --skip-duplicate


### PR DESCRIPTION
This PR addresses the need for a more secure build environment by adopting NuGet's "trusted publishing" feature for authenticating package push. Additionally, build and publish failures now prevent the GitHub release from being created for a given tag. 