### PR TITLE
Fix: `RootN(x, n)` should be equal to `-Pow(x, 1/n)` for odd nth roots.

### DIFF
--- a/QuadrupleLib.Tests/Math/PowerAndRootTests.cs
+++ b/QuadrupleLib.Tests/Math/PowerAndRootTests.cs
@@ -39,6 +39,9 @@ namespace QuadrupleLib.Tests.Math
         [InlineData(1.0)]
         [InlineData(2.1)]
         [InlineData(3.676)]
+        [InlineData(-1.0)]
+        [InlineData(-2.1)]
+        [InlineData(-3.676)]
         public void IsCbrtCorrect(double x)
         {
             double y = double.Cbrt(x);
@@ -52,6 +55,9 @@ namespace QuadrupleLib.Tests.Math
         [InlineData(1.0, 3)]
         [InlineData(2.1, 3)]
         [InlineData(3.676, 3)]
+        [InlineData(-1.0, 3)]
+        [InlineData(-2.1, 3)]
+        [InlineData(-3.676, 3)]
         [InlineData(1.0, 4)]
         [InlineData(2.1, 4)]
         [InlineData(3.676, 4)]
@@ -68,13 +74,19 @@ namespace QuadrupleLib.Tests.Math
         [InlineData(1.0, 3)]
         [InlineData(2.1, 3)]
         [InlineData(3.676, 3)]
+        [InlineData(-1.0, 3)]
+        [InlineData(-2.1, 3)]
+        [InlineData(-3.676, 3)]
         [InlineData(1.0, 4)]
         [InlineData(2.1, 4)]
         [InlineData(3.676, 4)]
         public void IsRootNEqualToPow(double x, int n)
         {
             Float128<TAccelerator> y0 = Float128<TAccelerator>.RootN(x, n);
-            Float128<TAccelerator> y1 = Float128<TAccelerator>.Pow(x, Float128<TAccelerator>.One / n);
+            Float128<TAccelerator> y1 = Float128<TAccelerator>.Pow(
+                Float128<TAccelerator>.Abs(x), Float128<TAccelerator>.One / n
+                );
+            if (x < 0.0) y1 = -y1;
             AssertX.NearlyEqual(y0, y1, Precision.NearestTenThousandth);
         }
 

--- a/QuadrupleLib/Modules/MathOperations.cs
+++ b/QuadrupleLib/Modules/MathOperations.cs
@@ -560,7 +560,7 @@ public partial struct Float128<TAccelerator>
 
     public static Float128<TAccelerator> Pow(Float128<TAccelerator> x, Float128<TAccelerator> y)
     {
-        if (IsZero(x) && IsZero(y)) 
+        if (IsZero(x) && IsZero(y))
         {
             return _sNaN;
         }
@@ -574,7 +574,7 @@ public partial struct Float128<TAccelerator>
 
             return result;
         }
-        else
+        else 
         {
             return Exp(y * Log(x));
         }
@@ -629,7 +629,7 @@ public partial struct Float128<TAccelerator>
         }
         else if (x < Zero)
         {
-            return (n & 1) == 0 ? _sNaN : -Pow(-x, n);
+            return (n & 1) == 0 ? _sNaN : -Pow(-x, One / n);
         }
         else
         {


### PR DESCRIPTION
This PR addresses a bug introduced by #83 where `RootN` would return incorrect results for odd roots of negative numbers. The issue was fixed and tests were added to prevent this bug in the future. 